### PR TITLE
Hide Header if the section is empty

### DIFF
--- a/library/src/main/java/com/afollestad/sectionedrecyclerview/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/com/afollestad/sectionedrecyclerview/SectionedRecyclerViewAdapter.java
@@ -70,8 +70,11 @@ public abstract class SectionedRecyclerViewAdapter<VH extends RecyclerView.ViewH
         int count = 0;
         mHeaderLocationMap.clear();
         for (int s = 0; s < getSectionCount(); s++) {
-            mHeaderLocationMap.put(count, s);
-            count += getItemCount(s) + 1;
+            int itemCount = getItemCount(s);
+            if(itemCount > 0) {
+                mHeaderLocationMap.put(count, s);
+                count += itemCount + 1;
+            }
         }
         return count;
     }


### PR DESCRIPTION
Does not display the header if the list is empty

It is possible to do it when extending your class but it is really easier to do this in the base class