### PR TITLE
Notify on insertion and removal for performance and animations.

### DIFF
--- a/library/src/main/java/com/afollestad/sectionedrecyclerview/PositionManager.java
+++ b/library/src/main/java/com/afollestad/sectionedrecyclerview/PositionManager.java
@@ -147,14 +147,6 @@ class PositionManager implements SectionedViewHolder.PositionDelegate {
     collapsedSectionMap.put(section, true);
   }
 
-  void toggleSectionExpanded(int section) {
-    if (collapsedSectionMap.get(section) != null) {
-      expandSection(section);
-    } else {
-      collapseSection(section);
-    }
-  }
-
   void expandAllSections() {
     for (int i = 0; i < itemProvider.getSectionCount(); i++) {
       expandSection(i);

--- a/library/src/main/java/com/afollestad/sectionedrecyclerview/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/com/afollestad/sectionedrecyclerview/SectionedRecyclerViewAdapter.java
@@ -49,12 +49,16 @@ public abstract class SectionedRecyclerViewAdapter<VH extends SectionedViewHolde
 
   public void expandSection(int section) {
     positionManager.expandSection(section);
-    notifyDataSetChanged();
+    notifyItemChanged(getSectionHeaderIndex(section));
+    int addFooter = showFooters() ? 1 : 0;
+    notifyItemRangeInserted(getAbsolutePosition(section, 0), getItemCount(section) + addFooter);
   }
 
   public void collapseSection(int section) {
     positionManager.collapseSection(section);
-    notifyDataSetChanged();
+    notifyItemChanged(getSectionHeaderIndex(section));
+    int addFooter = showFooters() ? 1 : 0;
+    notifyItemRangeRemoved(getAbsolutePosition(section, 0), getItemCount(section) + addFooter);
   }
 
   public void expandAllSections() {
@@ -74,8 +78,11 @@ public abstract class SectionedRecyclerViewAdapter<VH extends SectionedViewHolde
   }
 
   public void toggleSectionExpanded(int section) {
-    positionManager.toggleSectionExpanded(section);
-    notifyDataSetChanged();
+    if (positionManager.isSectionExpanded(section)) {
+      collapseSection(section);
+    } else {
+      expandSection(section);
+    }
   }
 
   public abstract int getSectionCount();

--- a/library/src/test/java/com/afollestad/sectionedrecyclerview/PositionManagerTest.java
+++ b/library/src/test/java/com/afollestad/sectionedrecyclerview/PositionManagerTest.java
@@ -299,16 +299,6 @@ public class PositionManagerTest {
   }
 
   @Test
-  public void test_toggle_expanded() {
-    positionManager.collapseSection(1);
-    assertThat(invalidate()).isEqualTo(7);
-    positionManager.toggleSectionExpanded(1);
-    assertThat(invalidate()).isEqualTo(12);
-    positionManager.toggleSectionExpanded(1);
-    assertThat(invalidate()).isEqualTo(7);
-  }
-
-  @Test
   public void test_has_invalidated() {
     assertThat(positionManager.hasInvalidated()).isTrue();
   }


### PR DESCRIPTION
First, thank you very much for making this, exactly what I needed! Except for missing animation support which this PR fixes.

Stop using `notifyDataSetChanged` in favor of `notifyItemRangeRemoved`/`Inserted` where suitable. This is better for performance and also enables animations from the RecyclerView's ItemAnimator. Fixes #51.

This is what it looks on the sample:

![](http://g.recordit.co/BR6a61rKFj.gif)